### PR TITLE
Add branch protection rule to chariott repo

### DIFF
--- a/otterdog/eclipse-chariott.jsonnet
+++ b/otterdog/eclipse-chariott.jsonnet
@@ -33,6 +33,12 @@ orgs.newOrg('eclipse-chariott') {
       secret_scanning: "disabled",
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+        },
+      ],
     },
   ],
 }


### PR DESCRIPTION
This PR adds a branch protection rule to the chariott repo as requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3409.

It also enables status checks and enforces the eca validation. Please let me know if you do not want that, but its good practice and suggested by the EF.

Please take a look at the comment automatically added by the validation workflow. It will highlight all settings that the new branch protection rule will have.

After it has been approved, it will be merged and the changes applied to GitHub.