### PR TITLE
Add branch protection rules to Agemo repo

### DIFF
--- a/otterdog/eclipse-chariott.jsonnet
+++ b/otterdog/eclipse-chariott.jsonnet
@@ -20,11 +20,16 @@ orgs.newOrg('eclipse-chariott') {
   _repositories+:: [
     orgs.newRepo('Agemo') {
       allow_update_branch: false,
-      dependabot_alerts_enabled: false,
       description: "Agemo",
       secret_scanning: "disabled",
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          required_approving_review_count: 1,
+        },
+      ],
     },
     orgs.newRepo('chariott') {
       allow_update_branch: false,


### PR DESCRIPTION
Add branch protection rules to the Agemo repo to match the other repo protection rules. Additionally, enabled dependabot alerts.