### PR TITLE
Set dependabot_security_updates_enabled to true for all repos

### DIFF
--- a/otterdog/eclipse-chariott.jsonnet
+++ b/otterdog/eclipse-chariott.jsonnet
@@ -13,6 +13,7 @@ orgs.newOrg('eclipse-chariott') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
       description: "Agemo",
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -26,6 +27,7 @@ orgs.newOrg('eclipse-chariott') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
       description: "chariott",
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -39,6 +41,7 @@ orgs.newOrg('eclipse-chariott') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
       description: "Chariott example applications and integrations with other components",
       web_commit_signoff_required: false,
       branch_protection_rules: [


### PR DESCRIPTION
This change enables dependabot_security_updates_enabled for all repositories. This setting allows dependabot to propose security vulnerability fixes if it can. It will create a new PR for review.